### PR TITLE
Update grctb.4606.1.tb.xml

### DIFF
--- a/public/xml/CITE_TREEBANK_XML/perseus/grctb/4606/grctb.4606.1.tb.xml
+++ b/public/xml/CITE_TREEBANK_XML/perseus/grctb/4606/grctb.4606.1.tb.xml
@@ -142,7 +142,7 @@
       <word id="116" form="καὶ" lemma="καί" postag="c--------" relation="ADV" head="17"/>
       <word id="117" form="εἰς" lemma="εἰς" postag="r--------" relation="AuxP" head="17"/>
       <word id="118" form="τὸ" lemma="ὁ" postag="l-s---na-" relation="ATR" head="119"/>
-      <word id="119" form="ἅγιονπνεῦμα" lemma="ἅγιονπνεῦμα" postag="l-s---na-" relation="A-ORIENT_CO" head="117"/>
+      <word id="119" form="ἅγιονπνεῦμα" lemma="ἅγιονπνεῦμα" postag="n-s---na-" relation="A-ORIENT_CO" head="117"/>
       <word id="120" form="." lemma="punc1" postag="u--------" relation="AuxK" head="0"/>
       <word id="121" insertion_id="0041e" artificial="elliptic" relation="NOM-DIRSTAT_PRED" form="(ἐγεννήθη)" head="36"/>
       <word id="122" insertion_id="0043e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="43"/>


### PR DESCRIPTION
Tagged ἅγιονπνεῦμα as a noun instead of an article.