### PR TITLE
Fix ἅγιονπνεῦμα in grctb.4606.1.tb.xml

### DIFF
--- a/public/xml/CITE_TREEBANK_XML/perseus/grctb/4606/grctb.4606.1.tb.xml
+++ b/public/xml/CITE_TREEBANK_XML/perseus/grctb/4606/grctb.4606.1.tb.xml
@@ -60,23 +60,23 @@
       <word id="34" form="," lemma="punc1" postag="u--------" relation="PARENTH" head="32"/>
       <word id="35" form="τουτ'" lemma="οὗτος" postag="p-s---nn-" relation="N-SUBJ" head="36"/>
       <word id="36" form="-έστιν" lemma="εἰμί" postag="v3spia---" relation="PRED" head="34"/>
-      <word id="37" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="121"/>
+      <word id="37" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="122"/>
       <word id="38" form="τῆς" lemma="ὁ" postag="l-s---fg-" relation="ATR" head="39"/>
       <word id="39" form="οὐσίας" lemma="οὐσία" postag="n-s---fg-" relation="G-ORIENT" head="37"/>
       <word id="40" form="τοῦ" lemma="ὁ" postag="l-s---mg-" relation="ATR" head="41"/>
       <word id="41" form="πατρός" lemma="πατήρ" postag="n-s---mg-" relation="G-POSS" head="39"/>
       <word id="42" form="," lemma="punc1" postag="u--------" relation="AuxX" head="36"/>
       <word id="43" form="θεὸν" lemma="θεός" postag="n-s---ma-" relation="A-ORIENT_AP" head="23"/>
-      <word id="44" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="122"/>
+      <word id="44" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="123"/>
       <word id="45" form="θεοῦ" lemma="θεός" postag="n-s---mg-" relation="G-ORIENT" head="44"/>
       <word id="46" form="," lemma="punc1" postag="u--------" relation="AuxX" head="23"/>
       <word id="47" form="φῶς" lemma="φάος" postag="n-s---nn-" relation="A-ORIENT_AP" head="23"/>
-      <word id="48" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="123"/>
+      <word id="48" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="124"/>
       <word id="49" form="φωτός" lemma="φάος" postag="n-s---ng-" relation="G-ORIENT" head="48"/>
       <word id="50" form="," lemma="punc1" postag="u--------" relation="AuxX" head="23"/>
       <word id="51" form="θεὸν" lemma="θεός" postag="n-s---ma-" relation="A-ORIENT_AP" head="23"/>
       <word id="52" form="ἀληθινὸν" lemma="ἀληθινός" postag="a-s---ma-" relation="ATR" head="51"/>
-      <word id="53" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="124"/>
+      <word id="53" form="ἐκ" lemma="ἐκ" postag="r--------" relation="AuxP" head="125"/>
       <word id="54" form="θεοῦ" lemma="θεός" postag="n-s---mg-" relation="G-ORIENT" head="53"/>
       <word id="55" form="ἀληθινοῦ" lemma="ἀληθινός" postag="a-s---mg-" relation="ATR" head="54"/>
       <word id="56" form="," lemma="punc1" postag="u--------" relation="AuxX" head="51"/>
@@ -92,10 +92,10 @@
       <word id="66" form="'" lemma="punc1" postag="u--------" relation="AuxG" head="65"/>
       <word id="67" form="οὗ" lemma="ὅς" postag="p-s---mg-" relation="G-CAUSE" head="65"/>
       <word id="68" form="τὰ" lemma="ὁ" postag="l-p---nn-" relation="ATR" head="69"/>
-      <word id="69" form="πάντα" lemma="πᾶς" postag="a-p---nn-" relation="N-SUBJ_AP" head="125"/>
+      <word id="69" form="πάντα" lemma="πᾶς" postag="a-p---nn-" relation="N-SUBJ_AP" head="126"/>
       <word id="70" form="ἐγένετο" lemma="γίγνομαι" postag="v3saim---" relation="ADJ-RC" head="51"/>
       <word id="71" form="τά" lemma="ὁ" postag="l-p---nn-" relation="N-SUBJ_CO" head="72"/>
-      <word id="72" form="τε" lemma="τε" postag="d--------" relation="COORD" head="125"/>
+      <word id="72" form="τε" lemma="τε" postag="d--------" relation="COORD" head="126"/>
       <word id="73" form="ἐν" lemma="ἐν" postag="r--------" relation="AuxP" head="71"/>
       <word id="74" form="τῷ" lemma="ὁ" postag="l-s---md-" relation="ATR" head="75"/>
       <word id="75" form="οὐρανῷ" lemma="οὐρανός" postag="n-s---md-" relation="D-LOCAT" head="73"/>
@@ -141,13 +141,14 @@
       <word id="115" form="." lemma="punc1" postag="u--------" relation="AuxX" head="17"/>
       <word id="116" form="καὶ" lemma="καί" postag="c--------" relation="ADV" head="17"/>
       <word id="117" form="εἰς" lemma="εἰς" postag="r--------" relation="AuxP" head="17"/>
-      <word id="118" form="τὸ" lemma="ὁ" postag="l-s---na-" relation="ATR" head="119"/>
-      <word id="119" form="ἅγιονπνεῦμα" lemma="ἅγιονπνεῦμα" postag="n-s---na-" relation="A-ORIENT_CO" head="117"/>
-      <word id="120" form="." lemma="punc1" postag="u--------" relation="AuxK" head="0"/>
-      <word id="121" insertion_id="0041e" artificial="elliptic" relation="NOM-DIRSTAT_PRED" form="(ἐγεννήθη)" head="36"/>
-      <word id="122" insertion_id="0043e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="43"/>
-      <word id="123" insertion_id="0047e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="47"/>
-      <word id="124" insertion_id="0052e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="51"/>
-      <word id="125" insertion_id="0070e" artificial="elliptic" relation="APOS" form="[ ]" head="70"/>
+      <word id="118" form="τὸ" lemma="ὁ" postag="l-s---na-" relation="ATR" head="120"/>
+      <word id="119" form="ἅγιον" lemma="ἅγιος" postag="a-s---na-" relation="ATR" head="120"/>
+      <word id="120" form="πνεῦμα" lemma="πνεῦμα" postag="n-s---na-" relation="A-ORIENT_CO" head="117"/>
+      <word id="121" form="." lemma="punc1" postag="u--------" relation="AuxK" head="0"/>
+      <word id="122" insertion_id="0041e" artificial="elliptic" relation="NOM-DIRSTAT_PRED" form="(ἐγεννήθη)" head="36"/>
+      <word id="123" insertion_id="0043e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="43"/>
+      <word id="124" insertion_id="0047e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="47"/>
+      <word id="125" insertion_id="0052e" artificial="elliptic" relation="ATR" form="(γεννηθέντα)" head="51"/>
+      <word id="126" insertion_id="0070e" artificial="elliptic" relation="APOS" form="[ ]" head="70"/>
    </sentence>
 </treebank>


### PR DESCRIPTION
* Tag ἅγιονπνεῦμα as a noun instead of an article (see https://github.com/perseids-publications/harrington-trees/pull/4)
* Split ἅγιονπνεῦμα into two words